### PR TITLE
[Code Coverage] Sonar report path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ report:
 	./gradlew jacocoTest${FLAVOR}${BUILD_TYPE}UnitTestReport --continue --console 'plain' ${GRADLEARGS}
 
 sonarqube:
-	./gradlew sonarqube --continue --console 'plain' ${GRADLEARGS}
+	./scripts/sonar-scan.sh ${FLAVOR} ${BUILD_TYPE}
 
 analysis: unit-test report sonarqube
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,28 +26,13 @@ plugins {
 }
 
 sonarqube {
-    def flavorName = ""
-    def buildType = ""
-    if (project.hasProperty("flavor")) {
-        flavorName = flavor
-        buildType = "Release"
-        androidVariant flavorName + buildType
-    } else {
-        buildType = "Debug"
-        androidVariant buildType
-    }
-
     properties {
         property "sonar.projectName", "Android App Template"
         property "sonar.projectKey", "curious-coding_android-app"
+        property "sonar.organization", "curious-coding"
         property "sonar.java.source", "8"
         property "sonar.sourceEncoding", "UTF-8"
         property "sonar.language", "java"
-
-        property "sonar.java.binaries", "build/tmp/kotlin-classes/${flavorName}${buildType.capitalize()}/"
-        property "sonar.java.test.binaries", "build/tmp/kotlin-classes/${flavorName}${buildType.capitalize()}/"
-
-        property "sonar.coverage.jacoco.xmlReportPaths", "build/reports/jacoco/jacocoTest${flavorName.capitalize()}${buildType.capitalize()}UnitTestReport/"
         property "sonar.java.coveragePlugin", "jacoco"
         property "sonar.exclusions", "**/*.js,**/*.css,**/*.html"
     }

--- a/scripts/sonar-scan.sh
+++ b/scripts/sonar-scan.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+
+FLAVOR="${1-Production}"
+BUILD_TYPE="${2-Release}"
+
+REPO_DIR="$( cd "$( dirname "$0" )/../" && pwd )"
+
+${REPO_DIR}/gradlew -p "$REPO_DIR" sonarqube \
+ -Dsonar.java.binaries=${REPO_DIR}build/tmp/kotlin-classes/${FLAVOR}${BUILD_TYPE}/ \
+  -Dsonar.java.test.binaries=${REPO_DIR}build/tmp/kotlin-classes/${FLAVOR}${BUILD_TYPE}/ \
+  -Dsonar.coverage.jacoco.xmlReportPaths=${REPO_DIR}/app/build/reports/jacoco/jacocoTest${FLAVOR}${BUILD_TYPE}UnitTestReport/jacocoTest${FLAVOR}${BUILD_TYPE}UnitTestReport.xml


### PR DESCRIPTION
This introduces `sonar-scan.sh` to enable flavorized scans.